### PR TITLE
change PWP::Encoding to PWP::SingleEncoding

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,7 @@ copyright_year   = 2011
 Method::Signatures = 20111020
 Dist::Zilla::Plugin::Bootstrap::lib = 0.01023600
 Test::CPAN::Meta::JSON = 0
-Pod::Weaver::Plugin::Encoding = 0
+Pod::Weaver = 4.000
 
 [Bootstrap::lib]
 [@Author::MELO]

--- a/lib/Pod/Weaver/PluginBundle/Author/MELO.pm
+++ b/lib/Pod/Weaver/PluginBundle/Author/MELO.pm
@@ -10,7 +10,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use Pod::Weaver 3.101633 ();
+use Pod::Weaver 4.000 ();
 use Pod::Weaver::PluginBundle::Default ();
 use Pod::Weaver::Plugin::StopWords 1.001005 ();
 use Pod::Weaver::Plugin::Transformer ();

--- a/lib/Pod/Weaver/PluginBundle/Author/MELO.pm
+++ b/lib/Pod/Weaver/PluginBundle/Author/MELO.pm
@@ -44,7 +44,7 @@ sub mvp_bundle_config {
   push @plugins, (
 
     # plugin
-    _plain('-Encoding'),
+    _plain('-SingleEncoding'),
     _plain('-WikiDoc'),
 
     # default
@@ -158,7 +158,7 @@ with the following additions:
 
 It is roughly equivalent to:
 
-  [Encoding]                ; prepend '=encoding utf-8' automatically
+  [SingleEncoding]          ; prepend '=encoding UTF-8' automatically
   [WikiDoc]                 ; transform wikidoc sections to POD
   [@CorePrep]               ; [@Default]
 


### PR DESCRIPTION
Hi,

`Pod::Weaver` now has`SingleEncoding` plugin (starting from 4.000), which makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
